### PR TITLE
feat: :sparkles: create k8s control plane and worker instances

### DIFF
--- a/bin/cdk-base.ts
+++ b/bin/cdk-base.ts
@@ -1,21 +1,10 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
-import { NetworkStack } from '../lib/cdk-network-stack';
+import { NetworkStack } from '../lib/network-stack';
+import { ComputeStack } from '../lib/compute-stack';
+
 
 const app = new cdk.App();
-new NetworkStack(app, 'CdkBaseStack', {
-  /* If you don't specify 'env', this stack will be environment-agnostic.
-   * Account/Region-dependent features and context lookups will not work,
-   * but a single synthesized template can be deployed anywhere. */
-
-  /* Uncomment the next line to specialize this stack for the AWS Account
-   * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-
-  /* Uncomment the next line if you know exactly what Account and Region you
-   * want to deploy the stack to. */
-  // env: { account: '123456789012', region: 'us-east-1' },
-
-  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
-});
+const networkStack = new NetworkStack(app, 'NetworkStack');
+new ComputeStack(app, 'ApplicationStack', { vpc: networkStack.vpc });

--- a/lib/compute-stack.ts
+++ b/lib/compute-stack.ts
@@ -1,0 +1,33 @@
+import { Stack, StackProps, aws_ec2 as ec2 } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+export class ComputeStack extends Stack {
+    constructor(scope: Construct, id: string, props: StackProps & { vpc: ec2.Vpc }) {
+    super(scope, id, props);
+
+    // Create a K8S Control Plane EC2 instance in the Application subnet
+    const controlPlaneInstance = new ec2.Instance(this, 'ControlPlane', {
+        vpc: props.vpc,
+        vpcSubnets: {
+            subnetGroupName: 'Application'  // This will select all subnets named 'Application'
+        },
+        machineImage: ec2.MachineImage.latestAmazonLinux2(),
+        instanceType: new ec2.InstanceType('t3.nano'),
+        });
+
+    // Create a worker EC2 instance in the Application subnet
+    const workerInstance = new ec2.Instance(this, 'Worker', {
+        vpc: props.vpc,
+        vpcSubnets: {
+            subnetGroupName: 'Application'  // This will select all subnets named 'Application'
+        },
+        machineImage: ec2.MachineImage.latestAmazonLinux2(),
+        instanceType: new ec2.InstanceType('t3.nano'),
+        blockDevices: [{
+            deviceName: '/dev/sdh',  // This is the device name; adjust if necessary
+            volume: ec2.BlockDeviceVolume.ebs(10)  // 10 GB EBS volume
+            }]
+        });
+    }
+}
+

--- a/lib/network-stack.ts
+++ b/lib/network-stack.ts
@@ -4,11 +4,13 @@ import { Construct } from 'constructs';
 
 
 export class NetworkStack extends cdk.Stack {
+  public readonly vpc: Vpc;
+
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     // Create a VPC with 2 AZs
-    const vpc = new Vpc(this, 'KubernetesAppVPC', {
+    this.vpc = new Vpc(this, 'kubernetesAppVpc', {
       ipAddresses: IpAddresses.cidr('10.11.0.0/16'),
       maxAzs: 3,
       // Define the subnet configuration


### PR DESCRIPTION
- create 3-tier network stack. App stack is isolated without NAT gateway
- add two ec2 instances to application stack. one will be k8s control plane. other will be worker node.