### PR TITLE
feat: :sparkles: support ssm session manager across ec2 instance

### DIFF
--- a/bin/cdk-base.ts
+++ b/bin/cdk-base.ts
@@ -12,7 +12,6 @@ const config = getConfig();
 
 const app = new cdk.App();
 const networkStack = new NetworkStack(app, 'NetworkStack');
-const endpointStack = new EndpointStack(app, 'EndpointStack', {vpc: networkStack.vpc});
 const bastionStack = new BastionHostStack(app, 'BastionStack', 
   {
       vpc: networkStack.vpc, 
@@ -26,6 +25,9 @@ const k8scontrolPlaneStack = new k8sControlPlaneStack(app, 'k8sControlPlaneStack
     domain: config.DOMAIN,
     ssh_port: config.SSH_PORT,
   });
+
+const endpointStack = new EndpointStack(app, 'EndpointStack', {vpc: networkStack.vpc});
+
 
 const k8sworkerStack = new k8sWorkerStack(app, 'k8sWorkerStack', 
   { vpc: networkStack.vpc,

--- a/lib/stacks/endpoint-stack.ts
+++ b/lib/stacks/endpoint-stack.ts
@@ -18,12 +18,33 @@ export class EndpointStack extends Stack {
             subnets: [{ subnetGroupName: 'Application' }]
         });
 
-        // Optionally, restrict policies to allow only specific bucket
+        // Restrict policies to allow only specific bucket
         s3Endpoint.addToPolicy(new iam.PolicyStatement({
             actions: ["s3:GetObject", "s3:ListBucket"],
             resources: [`arn:aws:s3:::${bucketName}`, `arn:aws:s3:::${bucketName}/*`],
             principals: [new iam.ArnPrincipal('*')],
             effect: iam.Effect.ALLOW
         }));
+
+            // SSM VPC Endpoints
+        const ssmEndpoint = props.vpc.addInterfaceEndpoint('SsmEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.SSM,
+            subnets: { subnetGroupName: 'Application' }
+        });
+
+        const ssmMessagesEndpoint = props.vpc.addInterfaceEndpoint('SsmMessagesEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.SSM_MESSAGES,
+            subnets: { subnetGroupName: 'Application'},
+        });
+        const ec2MessagesEndpoint = props.vpc.addInterfaceEndpoint('Ec2MessagesEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.EC2_MESSAGES,
+            subnets: { subnetGroupName: 'Application'},
+        });
+    
+        const kmsEndpoint = props.vpc.addInterfaceEndpoint('KmsEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.KMS,
+            subnets: { subnetGroupName: 'Application'},
+        });
+
     }
 }

--- a/lib/stacks/k8s-control-plane-stack.ts
+++ b/lib/stacks/k8s-control-plane-stack.ts
@@ -1,6 +1,7 @@
 import { Stack, StackProps, Duration, aws_ec2 as ec2 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as iam from 'aws-cdk-lib/aws-iam';
 
 export class k8sControlPlaneStack extends Stack {
     constructor(scope: Construct, id: string, props: StackProps & { 
@@ -19,19 +20,31 @@ export class k8sControlPlaneStack extends Stack {
         });
 
         // Allow SSH access on port in props.ssh_port
-        bastionSecurityGroup.addIngressRule(ec2.Peer.securityGroupId(props.bastionSgId), ec2.Port.tcp(parseInt(props.ssh_port) || 22), `Allow SSH access from the internet on port ${props.ssh_port}`);
+        bastionSecurityGroup.addIngressRule(
+            ec2.Peer.securityGroupId(props.bastionSgId), 
+            ec2.Port.tcp(parseInt(props.ssh_port) || 22), 
+            `Allow SSH access from the internet on port ${props.ssh_port}`);
         
         const keyPair = ec2.KeyPair.fromKeyPairName(this, 'KeyPair', 'k8s-cluster-demo');
         
+        // Create an IAM role for the bastion host
+        const role = new iam.Role(this, 'k8sControlPlaneRole', {
+            assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+            managedPolicies: [
+                iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
+                iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonEC2RoleforSSM')
+            ],
+        });
+
         const cfn_init = ec2.CloudFormationInit.fromElements(
 
-            ec2.InitCommand.shellCommand('sleep 10'),
-            ec2.InitFile.fromFileInline(
-                '/etc/ssh.sh',
-                './lib/scripts/ssh.sh', 
-            ),
-            ec2.InitCommand.shellCommand('chmod +x /etc/ssh.sh'),
-            ec2.InitCommand.shellCommand(`/etc/ssh.sh ${props.ssh_port}`),
+            // ec2.InitCommand.shellCommand('sleep 10'),
+            // ec2.InitFile.fromFileInline(
+            //     '/etc/ssh.sh',
+            //     './lib/scripts/ssh.sh', 
+            // ),
+            // ec2.InitCommand.shellCommand('chmod +x /etc/ssh.sh'),
+            // ec2.InitCommand.shellCommand(`/etc/ssh.sh ${props.ssh_port}`),
         );
 
         // Route 53 Hosted Zone for the domain
@@ -49,10 +62,11 @@ export class k8sControlPlaneStack extends Stack {
         instanceType: new ec2.InstanceType('t3.nano'),
         keyPair: keyPair, // Ensure this key is available in your AWS account
         securityGroup: bastionSecurityGroup,
-        init: cfn_init,
-        initOptions: {
-            timeout: Duration.minutes(15),
-        },
+        role: role,
+        // init: cfn_init,
+        // initOptions: {
+        //     timeout: Duration.minutes(5),
+        // },
         blockDevices: [{
             deviceName: '/dev/sdh',  // This is the device name; adjust if necessary
             volume: ec2.BlockDeviceVolume.ebs(10)  // 10 GB EBS volume

--- a/lib/stacks/k8s-worker-stack.ts
+++ b/lib/stacks/k8s-worker-stack.ts
@@ -1,6 +1,7 @@
 import { Stack, StackProps, Duration, aws_ec2 as ec2 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as iam from 'aws-cdk-lib/aws-iam';
 
 export class k8sWorkerStack extends Stack {
     constructor(scope: Construct, id: string, props: StackProps & { 
@@ -19,19 +20,31 @@ export class k8sWorkerStack extends Stack {
         });
 
         // Allow SSH access on port in props.ssh_port
-        bastionSecurityGroup.addIngressRule(ec2.Peer.securityGroupId(props.bastionSgId), ec2.Port.tcp(parseInt(props.ssh_port) || 22), `Allow SSH access from the internet on port ${props.ssh_port}`);
+        bastionSecurityGroup.addIngressRule(
+            ec2.Peer.securityGroupId(props.bastionSgId), 
+            ec2.Port.tcp(parseInt(props.ssh_port) || 22), 
+            `Allow SSH access from the internet on port ${props.ssh_port}`);
         
         const keyPair = ec2.KeyPair.fromKeyPairName(this, 'KeyPair', 'k8s-cluster-demo');
         
+        // Create an IAM role for the bastion host
+        const role = new iam.Role(this, 'k8sWorkerRole', {
+            assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+            managedPolicies: [
+                iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
+                iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonEC2RoleforSSM')
+            ],
+        });
+
         const cfn_init = ec2.CloudFormationInit.fromElements(
 
-            ec2.InitCommand.shellCommand('sleep 10'),
-            ec2.InitFile.fromFileInline(
-                '/etc/ssh.sh',
-                './lib/scripts/ssh.sh', 
-            ),
-            ec2.InitCommand.shellCommand('chmod +x /etc/ssh.sh'),
-            ec2.InitCommand.shellCommand(`/etc/ssh.sh ${props.ssh_port}`),
+            // ec2.InitCommand.shellCommand('sleep 10'),
+            // ec2.InitFile.fromFileInline(
+            //     '/etc/ssh.sh',
+            //     './lib/scripts/ssh.sh', 
+            // ),
+            // ec2.InitCommand.shellCommand('chmod +x /etc/ssh.sh'),
+            // ec2.InitCommand.shellCommand(`/etc/ssh.sh ${props.ssh_port}`),
         );
 
         // Route 53 Hosted Zone for the domain
@@ -49,10 +62,11 @@ export class k8sWorkerStack extends Stack {
         instanceType: new ec2.InstanceType('t3.nano'),
         keyPair: keyPair, // Ensure this key is available in your AWS account
         securityGroup: bastionSecurityGroup,
-        init: cfn_init,
-        initOptions: {
-            timeout: Duration.minutes(15),
-        },
+        role: role,
+        // init: cfn_init,
+        // initOptions: {
+        //     timeout: Duration.minutes(5),
+        // },
         blockDevices: [{
             deviceName: '/dev/sdh',  // This is the device name; adjust if necessary
             volume: ec2.BlockDeviceVolume.ebs(10)  // 10 GB EBS volume

--- a/lib/stacks/network-stack.ts
+++ b/lib/stacks/network-stack.ts
@@ -27,7 +27,7 @@ export class NetworkStack extends cdk.Stack {
         {
           cidrMask: 24,
           name: 'Application',
-          subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+          subnetType: SubnetType.PRIVATE_ISOLATED,
         },
         {
           cidrMask: 28,


### PR DESCRIPTION
SSM Session managere works only for bastion host which in the public tier and has a public IP. Despite required endpoints for SSM Session manager are being provisioned it does not yet work for the controlplane and worker ec2 instances, which are in private subnets.